### PR TITLE
fixing anneal rate

### DIFF
--- a/GumbelVAE.ipynb
+++ b/GumbelVAE.ipynb
@@ -45,6 +45,9 @@
     "nb_epoch = 100\n",
     "epsilon_std = 0.01\n",
     "\n",
+    "anneal_rate = 0.0003\n",
+    "min_temperature = 0.5\n",
+    "\n",
     "tau = K.variable(5.0, name=\"temperature\")\n",
     "x = Input(batch_shape=(batch_size, data_dim))\n",
     "h = Dense(256, activation='relu')(Dense(512, activation='relu')(x))\n",
@@ -91,7 +94,7 @@
     "        nb_epoch=1,\n",
     "        batch_size=batch_size,\n",
     "        validation_data=(x_test, x_test))\n",
-    "    K.set_value(tau, np.max([K.get_value(tau) * .0003, .5]))"
+    "    K.set_value(tau, np.max([K.get_value(tau) * np.exp(- anneal_rate * e), min_temperature]))"
    ]
   },
   {
@@ -219,7 +222,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "version": "2.7.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Seems like there was a typo in the `tau` adjustment -- in the current implementation, it goes from 5.0 to 0.5 immediately and stays there.  Compare that to line 25 of Jang's implementation:

https://gist.githubusercontent.com/ericjang/d30ed6e2528594a6b4421f45459abe74/raw/c516f2b767492441eb1b3e7ac83c47334e1094e4/gs-train.py

The current change is closer (though the actual rates might be somewhat different).