### PR TITLE
Correct loss

### DIFF
--- a/GumbelVAE.ipynb
+++ b/GumbelVAE.ipynb
@@ -75,7 +75,7 @@
     "    kl_tmp = q_y * (log_q_y - K.log(1.0/M))\n",
     "    KL = K.sum(kl_tmp, axis=(1, 2))\n",
     "    elbo = data_dim * bce(x, x_hat) - KL \n",
-    "    return elbo\n",
+    "    return -elbo\n",
     "\n",
     "vae = Model(x, x_hat)\n",
     "vae.compile(optimizer='adam', loss=gumbel_loss)\n",


### PR DESCRIPTION
As seen here:

https://github.com/ericjang/gumbel-softmax/blob/master/Categorical%20VAE.ipynb

`loss=tf.reduce_mean(-elbo)`